### PR TITLE
Fix errors in the multi-relaxation time collision model and the immersed boundary method

### DIFF
--- a/vivsim/ib.py
+++ b/vivsim/ib.py
@@ -121,6 +121,7 @@ def multi_direct_forcing(u, x, y, v_markers, x_markers, y_markers,
     g = jnp.zeros_like(u)
     h_markers = jnp.zeros((n_markers, 2))
     kernels = get_kernels(x_markers, y_markers, x, y, kernel_func)
+    seg_len_markers = jnp.reshape(seg_len_markers, (-1,1)) # make sure the shape is correct for multiplication
     for _ in range(n_iter):        
         # velocity at markers
         u_markers = jnp.einsum("dxy,nxy->nd", u, kernels) # fluid velocity at markers
@@ -144,6 +145,7 @@ def implicit(u, x, y, v_markers, x_markers, y_markers,
              seg_len_markers,  kernel_func=kernel_range4):
 
     kernels = get_kernels(x_markers, y_markers, x, y, kernel_func) 
+    seg_len_markers = jnp.reshape(seg_len_markers, (-1,1)) # make sure the shape is correct for multiplication
     
     # velocity at markers
     u_markers = jnp.einsum("dxy,nxy->nd", u, kernels) # fluid velocity at markers

--- a/vivsim/ib.py
+++ b/vivsim/ib.py
@@ -133,7 +133,7 @@ def multi_direct_forcing(u, x, y, v_markers, x_markers, y_markers,
         g += g_correction # accumulate required force to fluid at lattice points        
         
         # force to solid
-        h_markers -= u_markers_diff * seg_len_markers  # accumulate required force to solid at markers
+        h_markers -= g_markers_correction # accumulate required force to solid at markers
         
         # update velocity
         u += g_correction * 0.5 # correct fluid velocity at lattice points (Guo's forcing scheme)
@@ -157,7 +157,7 @@ def implicit(u, x, y, v_markers, x_markers, y_markers,
     u_correction = jnp.einsum("nd,nxy->dxy", u_markers_correction, kernels) # required fluid velocity correction at lattice points
     
     # required force correction
-    h_markers = - u_markers_correction * seg_len_markers # required force to solid at markers
+    h_markers = - u_markers_correction * 2 * seg_len_markers # required force to solid at markers
     g = u_correction * 2 * seg_len_markers # required force to fluid at lattice points
     
     return g, h_markers

--- a/vivsim/mrt.py
+++ b/vivsim/mrt.py
@@ -29,7 +29,7 @@ def get_relax_matrix(omega):
     """Get the relaxation matrix for the MRT collision model
     according to the given relaxation parameter omega."""
 
-    return jnp.diag(jnp.array([1, 1.4, 1.4, 1, 1.2, 1, 1.2, omega, omega]))
+    return jnp.diag(jnp.array([0, 1.4, 1.4, 0, 1.2, 0, 1.2, omega, omega]))
 
 def get_collision_left_matrix(M, S):
     """Pre-compute the constant left matrix for the MRT collision model.


### PR DESCRIPTION
The previously used relaxation matrix was [1, 1.4, 1.4, 1, 1.2, 1, 1.2, omega, omega]. The "1" relaxation rates correspond to the conserved moments of density and momentum and should actually be set to 0. (Credit to @NicolasGineys)

This adjustment will also resolve the downstream issue where the calculated lift and drag coefficients were inconsistent with the literature (see https://github.com/haimingz/vivsim/issues/17).