### PR TITLE
Add flexible body dynamics using VFIFE method

### DIFF
--- a/examples/vfife_beam.py
+++ b/examples/vfife_beam.py
@@ -1,0 +1,121 @@
+"""
+Vector Form Intrinsic Finite Element (VFIFE) for a flexible beam
+
+This example simulates the vibration of a flexible cantilever beam
+using the VFIFE method.
+"""
+
+import jax
+import jax.numpy as jnp
+import matplotlib.pyplot as plt
+from tqdm import tqdm
+
+from vivsim import dyn
+
+# ========================== GEOMETRY & MATERIAL =======================
+L = 10.0           # Length of the beam
+N_NODES = 20       # Number of nodes
+N_ELEM = N_NODES - 1
+
+EA = 1e6           # Axial stiffness
+EI = 1e4           # Bending stiffness
+RHO_L = 1.0        # Mass per unit length
+M_NODE = RHO_L * L / N_ELEM  # Mass per node
+J_NODE = M_NODE * (L / N_ELEM)**2 / 12  # Moment of inertia per node
+
+DAMPING = 0.5      # Damping coefficient
+
+# Initial positions
+x0 = jnp.linspace(0, L, N_NODES)
+y0 = jnp.zeros(N_NODES)
+x = jnp.stack([x0, y0], axis=-1)
+
+l0 = jnp.ones(N_ELEM) * (L / N_ELEM)
+
+# State variables
+v = jnp.zeros((N_NODES, 2))
+theta = jnp.zeros(N_NODES)
+omega = jnp.zeros(N_NODES)
+
+# Mass and moment of inertia arrays
+m = jnp.ones(N_NODES) * M_NODE
+J = jnp.ones(N_NODES) * J_NODE
+
+# External forces
+f_ext = jnp.zeros((N_NODES, 2))
+m_ext = jnp.zeros(N_NODES)
+
+# Apply initial displacement (e.g., pulling the tip)
+x = x.at[-1, 1].set(-2.0)
+
+# ========================== SIMULATION PARAMETERS =======================
+DT = 1e-4
+TM = 200000
+PLOT_FREQ = 2000
+
+# ========================== SIMULATION ROUTINE =====================
+@jax.jit
+def update(x, v, theta, omega):
+    x_next, v_next, theta_next, omega_next = dyn.vfife_beam(
+        x, v, theta, omega, f_ext, m_ext, m, J, EA, EI, l0, DT, DAMPING
+    )
+
+    # Boundary condition: fixed at left end (cantilever)
+    x_next = x_next.at[0].set(x[0])
+    v_next = v_next.at[0].set(0.0)
+    theta_next = theta_next.at[0].set(0.0)
+    omega_next = omega_next.at[0].set(0.0)
+
+    return x_next, v_next, theta_next, omega_next
+
+# ========================== RUN SIMULATION ==========================
+history_x = []
+history_y = []
+
+# Using scan for faster execution
+def run_chunk(carry, n_steps):
+    def step(carry, _):
+        x, v, theta, omega = carry
+        carry_next = update(x, v, theta, omega)
+        return carry_next, carry_next[0]  # Return x as output
+    return jax.lax.scan(step, carry, None, length=n_steps)
+
+run_chunk = jax.jit(run_chunk, static_argnums=1)
+
+carry = (x, v, theta, omega)
+
+# Run warmup
+carry, _ = run_chunk(carry, 10)
+
+print(f"Running simulation for {TM} steps...")
+with tqdm(total=TM) as pbar:
+    for i in range(TM // PLOT_FREQ):
+        carry, x_chunk = run_chunk(carry, PLOT_FREQ)
+        jax.block_until_ready(x_chunk)
+
+        # Save end position for plotting
+        x_last = x_chunk[-1]
+        history_x.append(x_last[:, 0])
+        history_y.append(x_last[:, 1])
+
+        pbar.update(PLOT_FREQ)
+
+print("Plotting results...")
+plt.figure(figsize=(10, 4))
+for i, (hx, hy) in enumerate(zip(history_x, history_y)):
+    if i % 10 == 0:  # plot every 10th saved frame
+        plt.plot(hx, hy, 'b-', alpha=float(i)/len(history_x)*0.8+0.2)
+
+plt.plot(history_x[-1], history_y[-1], 'r-', linewidth=2, label='Final state')
+plt.plot(x0, y0, 'k--', label='Initial undeformed')
+plt.plot(x[:, 0], x[:, 1], 'g:', label='Initial deformed')
+
+plt.xlim(-1, L + 1)
+plt.ylim(-3, 3)
+plt.grid(True)
+plt.legend()
+plt.title("VFIFE Cantilever Beam Vibration")
+plt.xlabel("X")
+plt.ylabel("Y")
+plt.savefig("vfife_beam_result.png")
+print("Saved plot to vfife_beam_result.png")

--- a/vivsim/dyn.py
+++ b/vivsim/dyn.py
@@ -152,3 +152,84 @@ def get_torque_to_obj(x_markers, y_markers, x_center_init, y_center_init, d, h_m
     y_rel = y_markers - (y_center_init + d[1])
     
     return jnp.sum(x_rel * h_markers[:, 1] - y_rel * h_markers[:, 0])
+# ----------------- Flexible Object Dynamics -----------------
+
+def vfife_beam(x, v, theta, omega, f_ext, m_ext, m, J, EA, EI, l0, dt, damping=0.0):
+    """Vector Form Intrinsic Finite Element (VFIFE) method for 2D flexible beams.
+
+    This function computes one time step of the explicit dynamics for a 2D beam
+    using the VFIFE method, which is well-suited for large deformations and JAX
+    parallelization.
+
+    Args:
+        x (ndarray of shape (N, 2)): Nodal positions at time t.
+        v (ndarray of shape (N, 2)): Nodal velocities at time t.
+        theta (ndarray of shape (N,)): Nodal rotations at time t.
+        omega (ndarray of shape (N,)): Nodal angular velocities at time t.
+        f_ext (ndarray of shape (N, 2)): External forces on nodes (e.g., fluid forces).
+        m_ext (ndarray of shape (N,)): External moments on nodes.
+        m (ndarray of shape (N,)): Node masses.
+        J (ndarray of shape (N,)): Node moments of inertia.
+        EA (float or ndarray of shape (N-1,)): Axial stiffness of elements.
+        EI (float or ndarray of shape (N-1,)): Bending stiffness of elements.
+        l0 (ndarray of shape (N-1,)): Initial length of elements.
+        dt (float): Time step size.
+        damping (float): Nodal damping coefficient.
+
+    Returns:
+        x_next (ndarray of shape (N, 2)): Nodal positions at time t+dt.
+        v_next (ndarray of shape (N, 2)): Nodal velocities at time t+dt.
+        theta_next (ndarray of shape (N,)): Nodal rotations at time t+dt.
+        omega_next (ndarray of shape (N,)): Nodal angular velocities at time t+dt.
+    """
+
+    # Elements vector and length
+    dx = x[1:] - x[:-1]
+    L = jnp.linalg.norm(dx, axis=-1)
+
+    # Rigid body rotation of the element
+    alpha = jnp.arctan2(dx[:, 1], dx[:, 0])
+
+    # Pure deformations
+    delta_d = L - l0
+    theta_1d = theta[:-1] - alpha
+    theta_2d = theta[1:] - alpha
+
+    # Ensure angles are in [-pi, pi]
+    theta_1d = jnp.mod(theta_1d + jnp.pi, 2 * jnp.pi) - jnp.pi
+    theta_2d = jnp.mod(theta_2d + jnp.pi, 2 * jnp.pi) - jnp.pi
+
+    # Internal forces in local frame
+    fx = EA * delta_d / l0
+    m1 = (EI / l0) * (4 * theta_1d + 2 * theta_2d)
+    m2 = (EI / l0) * (2 * theta_1d + 4 * theta_2d)
+    fy = (m1 + m2) / L
+
+    # Transform internal forces to global frame
+    cos_a = dx[:, 0] / L
+    sin_a = dx[:, 1] / L
+
+    f1x = -fx * cos_a - fy * sin_a
+    f1y = -fx * sin_a + fy * cos_a
+    f2x = fx * cos_a + fy * sin_a
+    f2y = fx * sin_a - fy * cos_a
+
+    # Assemble global internal forces on nodes
+    f_int_x = jnp.pad(f1x, (0, 1)) + jnp.pad(f2x, (1, 0))
+    f_int_y = jnp.pad(f1y, (0, 1)) + jnp.pad(f2y, (1, 0))
+    m_int = jnp.pad(m1, (0, 1)) + jnp.pad(m2, (1, 0))
+
+    f_int = jnp.stack([f_int_x, f_int_y], axis=-1)
+
+    # Equations of motion
+    a = (f_ext - f_int - damping * v) / m[:, None]
+    alpha_acc = (m_ext - m_int - damping * omega) / J
+
+    # Update velocities and positions (Semi-implicit Euler)
+    v_next = v + a * dt
+    omega_next = omega + alpha_acc * dt
+
+    x_next = x + v_next * dt
+    theta_next = theta + omega_next * dt
+
+    return x_next, v_next, theta_next, omega_next


### PR DESCRIPTION
This PR adds support for computing the structural dynamics of 2D flexible beams using the Vector Form Intrinsic Finite Element (VFIFE) method.

The implementation is designed using `jax.numpy` pure functions, enabling seamless integration with the JAX-based IB-LBM fluid solver and out-of-the-box hardware acceleration (GPU/TPU) via XLA compilation. It explicitly updates nodal positions and orientations using a corotational formulation, which naturally handles large geometric nonlinearities.

An example demonstrating the dynamics of a flexible cantilever beam under initial displacement is also provided in `examples/vfife_beam.py`.

---
*PR created automatically by Jules for task [17361273965235304450](https://jules.google.com/task/17361273965235304450) started by @haimingz*